### PR TITLE
feat: add support to include flux-uri in cluster metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/compspec/compspec-containment/tree/main) (0.0.x)
+- Save flux URI with system for delegation (0.0.14)
 - Add cluster and hostname to metadata extraction (0.0.12)
 - Support for detect and check (0.0.11)
 - Support for detection (0.0.1)

--- a/compspec_containment/plugin.py
+++ b/compspec_containment/plugin.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import os
 
 import compspec.utils as utils
 from compspec.create.jsongraph import JsonGraph
@@ -129,6 +130,11 @@ class Plugin(PluginBase):
         g.metadata["name"] = cluster
         g.metadata["hostname"] = hostname or utils.get_hostname()
         g.metadata["install_name"] = name or self.name
+
+        # Add the Flux URI for later communication
+        g.metadata["flux_uri"] = os.environ.get("FLUX_URI")
+        if not g.metadata["flux_uri"]:
+            print("WARNING: FLUX_URI not detected.")
 
         # We need to convert from V1 to V2
         return g.to_jgfv2()

--- a/compspec_containment/version.py
+++ b/compspec_containment/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2024-2026, Vanessa Sochat"
 __license__ = "MIT"
 
-__version__ = "0.0.13"
+__version__ = "0.0.14"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "compspec-containment"


### PR DESCRIPTION
We need the URI for delegation to use